### PR TITLE
Avoid deleting XmlRpcClient's while they are being still in use on another thread

### DIFF
--- a/clients/roscpp/include/ros/xmlrpc_manager.h
+++ b/clients/roscpp/include/ros/xmlrpc_manager.h
@@ -84,6 +84,12 @@ public:
   XmlRpc::XmlRpcClient* client_;
 
   static const ros::WallDuration s_zombie_time_; // how long before it is toasted
+
+  // Conversion operator to check if pointer is valid
+  operator bool()
+  {
+    return client_;
+  }
 };
 
 class XMLRPCManager;

--- a/clients/roscpp/include/ros/xmlrpc_manager.h
+++ b/clients/roscpp/include/ros/xmlrpc_manager.h
@@ -86,7 +86,7 @@ public:
   static const ros::WallDuration s_zombie_time_; // how long before it is toasted
 
   // Conversion operator to check if pointer is valid
-  operator bool()
+  operator bool() const
   {
     return client_;
   }

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -170,15 +170,7 @@ void XMLRPCManager::shutdown()
 
     // Erase the deleted clients. The clients in use will delete themselves
     // on release
-    struct
-    {
-      bool operator() (const CachedXmlRpcClient& c)
-      {
-        return !(c.client_);
-      }
-    } is_deleted;
-
-    clients_.erase(std::remove_if(clients_.begin(), clients_.end(), is_deleted), clients_.end());
+    clients_.erase(std::remove(clients_.begin(), clients_.end(), false), clients_.end());
   }
 
   boost::mutex::scoped_lock lock(functions_mutex_);

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -163,14 +163,15 @@ void XMLRPCManager::shutdown()
     {
       if (!i->in_use_)
       {
-       i->client_->close();
-       delete i->client_;
+        i->client_->close();
+        delete i->client_;
       }
     }
 
     // Erase the deleted clients. The clients in use will delete themselves
     // on release
-    clients_.erase(std::remove(clients_.begin(), clients_.end(), false), clients_.end());
+    clients_.erase(std::remove(clients_.begin(), clients_.end(), false),
+		    clients_.end());
   }
 
   boost::mutex::scoped_lock lock(functions_mutex_);
@@ -372,16 +373,16 @@ void XMLRPCManager::releaseXMLRPCClient(XmlRpcClient *c)
   {
     if (c == i->client_)
     {
-      if (!shutting_down_)
-      {
-        i->in_use_ = false;
-      }
-      else
+      if (shutting_down_)
       {
         // if we are shutting down we won't be re-using the client
         i->client_->close();
         delete i->client_;
         clients_.erase(i);
+      }
+      else
+      {
+        i->in_use_ = false;
       }
       break;
     }


### PR DESCRIPTION

 * Acquire `clients_mutex_` before deleting the clients
 * Remove the timed wait for the clients to be not in use
 * Only delete and erase clients that are not in use
 * Clients that would still be in use would delete and erase themselves from `clients_` on release

@mikepurvis  @efernandez  @jasonimercer 