### PR TITLE
Fix bug in erasing cached XmlRpcClients on shutdown

### DIFF
--- a/clients/roscpp/include/ros/xmlrpc_manager.h
+++ b/clients/roscpp/include/ros/xmlrpc_manager.h
@@ -84,12 +84,6 @@ public:
   XmlRpc::XmlRpcClient* client_;
 
   static const ros::WallDuration s_zombie_time_; // how long before it is toasted
-
-  // Conversion operator to check if pointer is valid
-  operator bool() const
-  {
-    return client_;
-  }
 };
 
 class XMLRPCManager;

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -159,19 +159,19 @@ void XMLRPCManager::shutdown()
     boost::mutex::scoped_lock lock(clients_mutex_);
 
     for (V_CachedXmlRpcClient::iterator i = clients_.begin();
-         i != clients_.end(); ++i)
+         i != clients_.end();)
     {
       if (!i->in_use_)
       {
         i->client_->close();
         delete i->client_;
+        i = clients_.erase(i);
+      }
+      else
+      {
+        ++i;
       }
     }
-
-    // Erase the deleted clients. The clients in use will delete themselves
-    // on release
-    clients_.erase(std::remove(clients_.begin(), clients_.end(), false),
-		    clients_.end());
   }
 
   boost::mutex::scoped_lock lock(functions_mutex_);


### PR DESCRIPTION
deleted pointers are not set to null, so the erase/remove was not doing anything.

@deng02 