### PR TITLE
Implement rosbag en/decryption.

### DIFF
--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(rosbag_storage
   src/uncompressed_stream.cpp
 )
 
-target_link_libraries(rosbag_storage ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${BZIP2_LIBRARIES} ${console_bridge_LIBRARIES})
+target_link_libraries(rosbag_storage ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${BZIP2_LIBRARIES} ${console_bridge_LIBRARIES} crypto gpgme)
 
 install(TARGETS rosbag_storage
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/tools/rosbag_storage/include/rosbag/constants.h
+++ b/tools/rosbag_storage/include/rosbag/constants.h
@@ -61,6 +61,8 @@ static const std::string TIME_FIELD_NAME             = "time";          // 2.0+
 static const std::string START_TIME_FIELD_NAME       = "start_time";    // 2.0+
 static const std::string END_TIME_FIELD_NAME         = "end_time";      // 2.0+
 static const std::string CHUNK_POS_FIELD_NAME        = "chunk_pos";     // 2.0+
+static const std::string ENCRYPTION_USER_FIELD_NAME  = "encryption_user";
+static const std::string ENCRYPTED_KEY_FIELD_NAME    = "encrypted_key";
 
 // Legacy header fields
 static const std::string MD5_FIELD_NAME      = "md5";           // <2.0


### PR DESCRIPTION
To encrypt bag file content, call the `setEncryptionUser` method of the `rosbag::Bag` instance passing the user name of a GPG public key already added to system keyrings.  Without this call, the rosbag API works as before (no encryption).  To load an encrypted bag file, a GPG private key should be installed in your system.  If an error occurs during encryption/decryption, the API method is supposed to throw an exception.  This is believed to be a better approach as we cannot modify the source code of all the rosbag API clients.