### PR TITLE
added parameter to omit topics list from rosout logs

### DIFF
--- a/tools/rosout/rosout.cpp
+++ b/tools/rosout/rosout.cpp
@@ -116,7 +116,7 @@ public:
     std::cout << "subscribed to /rosout" << std::endl;
   }
 
-    void rosoutCallback(const rosgraph_msgs::Log::ConstPtr& msg)
+  void rosoutCallback(const rosgraph_msgs::Log::ConstPtr& msg)
   {
     agg_pub_.publish(msg);
 

--- a/tools/rosout/rosout.cpp
+++ b/tools/rosout/rosout.cpp
@@ -144,21 +144,27 @@ public:
     ss << msg->name << " ";
     ss << "[" << msg->file << ":" << msg->line << "(" << msg->function << ")] ";
 
-    ss << "[topics: ";
-    std::vector<std::string>::const_iterator it = msg->topics.begin();
-    std::vector<std::string>::const_iterator end = msg->topics.end();
-    for ( ; it != end; ++it )
+    // check parameter server for omit_topics_from_logs flag
+    int omit_topics_from_logs;
+    node_.param("/rosout/omit_topics_from_logs", omit_topics_from_logs, 0);
+    if (!omit_topics_from_logs)
     {
-      const std::string& topic = *it;
-
-      if ( it != msg->topics.begin() )
+      ss << "[topics: ";
+      std::vector<std::string>::const_iterator it = msg->topics.begin();
+      std::vector<std::string>::const_iterator end = msg->topics.end();
+      for ( ; it != end; ++it )
       {
-        ss << ", ";
-      }
+        const std::string& topic = *it;
 
-      ss << topic;
+        if ( it != msg->topics.begin() )
+        {
+          ss << ", ";
+        }
+
+        ss << topic;
+      }
+      ss << "] ";
     }
-    ss << "] ";
 
     ss << msg->msg;
     ss << "\n";

--- a/tools/rosout/rosout.cpp
+++ b/tools/rosout/rosout.cpp
@@ -114,7 +114,6 @@ public:
 
     rosout_sub_ = node_.subscribe("/rosout", 0, &Rosout::rosoutCallback, this);
     std::cout << "subscribed to /rosout" << std::endl;
-
   }
 
     void rosoutCallback(const rosgraph_msgs::Log::ConstPtr& msg)


### PR DESCRIPTION
Added parameter to omit topics list from rosout logs.The parameter `/rosout/omit_topics` stops `rosout.cpp` from adding the list of all topics to the logs. It does not stop rospy or roscpp from generating the list of topics and sending them over the network stack. This is addressed in [this accompanying PR](https://github.com/clearpathrobotics/ros_comm/pull/17).