### PR TITLE
added parameter to stop client libraries from generating topics

### DIFF
--- a/clients/roscpp/include/ros/rosout_appender.h
+++ b/clients/roscpp/include/ros/rosout_appender.h
@@ -75,6 +75,7 @@ protected:
   boost::mutex queue_mutex_;
   boost::condition_variable queue_condition_;
   bool shutting_down_;
+  bool omit_topics_;
 
   boost::thread publish_thread_;
 };

--- a/clients/roscpp/include/ros/rosout_appender.h
+++ b/clients/roscpp/include/ros/rosout_appender.h
@@ -75,7 +75,7 @@ protected:
   boost::mutex queue_mutex_;
   boost::condition_variable queue_condition_;
   bool shutting_down_;
-  bool omit_topics_;
+  bool disable_topics_;
 
   boost::thread publish_thread_;
 };

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -46,7 +46,7 @@ namespace ros
 {
 
 ROSOutAppender::ROSOutAppender()
-  : shutting_down_(false)
+: shutting_down_(false)
 , publish_thread_(boost::bind(&ROSOutAppender::logThread, this))
 {
   AdvertiseOptions ops;

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -107,13 +107,8 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   // check parameter server/cache for omit_topics flag
   ros::param::getCached("/rosclient/omit_topics", omit_topics_);
 
-  msg->name = omit_topics_;
-
   if (!omit_topics_){
     this_node::getAdvertisedTopics(msg->topics);
-  }
-  else {
-    msg->level = rosgraph_msgs::Log::FATAL;
   }
 
   if (level == ::ros::console::levels::Fatal || level == ::ros::console::levels::Error)

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -106,9 +106,9 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   
   // check parameter server/cache for omit_topics flag
   // the same parameter is checked in rosout.py for the same purpose
-  ros::param::getCached("/rosout_disable_topics_generation", omit_topics_);
+  ros::param::getCached("/rosout_disable_topics_generation", disable_topics_);
 
-  if (!omit_topics_){
+  if (!disable_topics_){
     this_node::getAdvertisedTopics(msg->topics);
   }
 

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -105,7 +105,8 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   msg->line = line;
   
   // check parameter server/cache for omit_topics flag
-  ros::param::getCached("/rosclient/omit_topics", omit_topics_);
+  // the same parameter is checked in rosout.py for the same purpose
+  ros::param::getCached("/rosout_disable_topics_generation", omit_topics_);
 
   if (!omit_topics_){
     this_node::getAdvertisedTopics(msg->topics);

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -85,7 +85,13 @@ def _rosout(level, msg, fname, line, func):
                 try:
                     _in_rosout = True
                     msg = str(msg)
-                    topics = get_topic_manager().get_topics()
+
+                    # check parameter server/cache for omit_topics flag
+                    # parameter accesses are cached automatically in python
+                    omit_topics_ = rospy.getParam("/rosclient/omit_topics")
+                    if not omit_topics_:
+                        topics = get_topic_manager().get_topics()
+
                     l = Log(level=level, name=str(rospy.names.get_caller_id()), msg=str(msg), topics=topics, file=fname, line=line, function=func)
                     l.header.stamp = Time.now()
                     _rosout_pub.publish(l)

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -89,8 +89,8 @@ def _rosout(level, msg, fname, line, func):
                     # check parameter server/cache for omit_topics flag
                     # the same parameter is checked in rosout_appender.cpp for the same purpose
                     # parameter accesses are cached automatically in python
-                    omit_topics_ = rospy.getParam("/rosout_disable_topics_generation")
-                    if not omit_topics_:
+                    disable_topics_ = rospy.getParam("/rosout_disable_topics_generation")
+                    if not disable_topics_:
                         topics = get_topic_manager().get_topics()
 
                     l = Log(level=level, name=str(rospy.names.get_caller_id()), msg=str(msg), topics=topics, file=fname, line=line, function=func)

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -87,8 +87,9 @@ def _rosout(level, msg, fname, line, func):
                     msg = str(msg)
 
                     # check parameter server/cache for omit_topics flag
+                    # the same parameter is checked in rosout_appender.cpp for the same purpose
                     # parameter accesses are cached automatically in python
-                    omit_topics_ = rospy.getParam("/rosclient/omit_topics")
+                    omit_topics_ = rospy.getParam("/rosout_disable_topics_generation")
                     if not omit_topics_:
                         topics = get_topic_manager().get_topics()
 

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -96,6 +96,8 @@ def _rosout(level, msg, fname, line, func):
 
                     if not disable_topics_:
                         topics = get_topic_manager().get_topics()
+                    else:
+                        topics = ""
 
                     l = Log(level=level, name=str(rospy.names.get_caller_id()), msg=str(msg), topics=topics, file=fname, line=line, function=func)
                     l.header.stamp = Time.now()

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -89,7 +89,11 @@ def _rosout(level, msg, fname, line, func):
                     # check parameter server/cache for omit_topics flag
                     # the same parameter is checked in rosout_appender.cpp for the same purpose
                     # parameter accesses are cached automatically in python
-                    disable_topics_ = rospy.getParam("/rosout_disable_topics_generation")
+                    if rospy.has_param("/rosout_disable_topics_generation"):
+                        disable_topics_ = rospy.get_param("/rosout_disable_topics_generation")
+                    else:
+                        disable_topics_ = False
+
                     if not disable_topics_:
                         topics = get_topic_manager().get_topics()
 


### PR DESCRIPTION
Added parameter to stop rospy and roscpp from generating the topics list and sending it to rosout. The parameter `/rosclient/omit_topics` stops `rosout_appender.cpp` and `rosout.py` from retrieving the list of topics for a node. It does not stop `rosout.cpp` from writing the list of topics, although the list it prints will be empty. [This accompanying PR](https://github.com/clearpathrobotics/ros_comm/pull/16) stops rosout from writing the list of topics to the log.